### PR TITLE
Make middleware customizable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: ruby
 rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.10.6
-cache:
-  - bundler
+  - 2.4.0

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ X-Runtime: 0.000578
 Connection: close
 ```
 
+## Customize
+
+You can customize the endpoint and HTTP status:
+
+```ruby
+# config/application.rb
+module YourAppName
+  class Application < Rails::Application
+    # [...]
+
+    config.health_endpoint = {
+      status: 200,    # default: 204
+      path: '/ping'   # default: '/health'
+    }
+  end
+end
+```
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,6 @@ require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
-  t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb']
 end
 

--- a/lib/wet/health_endpoint/middleware.rb
+++ b/lib/wet/health_endpoint/middleware.rb
@@ -1,8 +1,11 @@
 module Wet
   module HealthEndpoint
     class Middleware
-      def initialize(app)
+      DEFAULT_OPTIONS = {status: 204, path: '/health'}
+
+      def initialize(app, options)
         @app = app
+        @options = options || DEFAULT_OPTIONS
       end
 
       def call(env)
@@ -11,8 +14,12 @@ module Wet
 
       def _call(env)
         status, headers, body = @app.call(env)
-        return [204, {}, ['']] if status == 404 && env.fetch('PATH_INFO') == '/health'
-        [status, headers, body]
+
+        if status == 404 && env.fetch('PATH_INFO') == @options[:path]
+          [@options[:status], {}, ['']]
+        else
+          [status, headers, body]
+        end
       ensure
         body.close if body && body.respond_to?(:close) && $!
       end

--- a/lib/wet/health_endpoint/railtie.rb
+++ b/lib/wet/health_endpoint/railtie.rb
@@ -4,7 +4,7 @@ module Wet
   module HealthEndpoint
     class Railtie < Rails::Railtie
       initializer 'health_endpoint.routes' do |app|
-        app.middleware.use Middleware
+        app.middleware.use Middleware, app.config.try(:health_endpoint)
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,12 +2,3 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'minitest/autorun'
 require 'action_controller/railtie'
 require 'wet/health_endpoint'
-
-class DummyApplication < ::Rails::Application
-  config.eager_load      = false
-  config.secret_key_base = SecureRandom.hex(30)
-end
-
-DummyApplication.initialize!
-DummyApplication.routes.default_url_options[:host] = 'example.com'
-

--- a/test/wet/health_endpoint_test.rb
+++ b/test/wet/health_endpoint_test.rb
@@ -4,12 +4,17 @@ require 'rack/test'
 class Wet::HealthEndpointTest < Minitest::Test
   include Rack::Test::Methods
 
+  APP_INSTANCE = Class.new(::Rails::Application) {
+    config.eager_load = false
+    config.secret_key_base = SecureRandom.hex(30)
+  }.initialize!
+
   def app
-    Rails.application
+    APP_INSTANCE
   end
 
   def test_health_check_endpoint
-    app.routes.draw {}
+    app.routes.clear!
 
     get '/health'
 
@@ -24,8 +29,6 @@ class Wet::HealthEndpointTest < Minitest::Test
 
     assert_equal 200,   last_response.status
     assert_equal 'Yo!', last_response.body
-
-    app.routes.draw {}
   end
 end
 

--- a/test/wet/health_endpoint_with_options_test.rb
+++ b/test/wet/health_endpoint_with_options_test.rb
@@ -4,20 +4,18 @@ require 'rack/test'
 class Wet::HealthEndpointWithOptionsTest < Minitest::Test
   include Rack::Test::Methods
 
-  class DummyApplication < ::Rails::Application
+  APP_INSTANCE = Class.new(::Rails::Application) {
     config.eager_load = false
     config.secret_key_base = SecureRandom.hex(30)
     config.health_endpoint = {status: 200, path: '/ping'}
-  end
-
-  DummyApplication.initialize!
+  }.initialize!
 
   def app
-    DummyApplication
+    APP_INSTANCE
   end
 
   def test_health_check_endpoint
-    app.routes.draw {}
+    app.routes.clear!
 
     get '/ping'
 

--- a/test/wet/health_endpoint_with_options_test.rb
+++ b/test/wet/health_endpoint_with_options_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'rack/test'
+
+class Wet::HealthEndpointWithOptionsTest < Minitest::Test
+  include Rack::Test::Methods
+
+  class DummyApplication < ::Rails::Application
+    config.eager_load = false
+    config.secret_key_base = SecureRandom.hex(30)
+    config.health_endpoint = {status: 200, path: '/ping'}
+  end
+
+  DummyApplication.initialize!
+
+  def app
+    DummyApplication
+  end
+
+  def test_health_check_endpoint
+    app.routes.draw {}
+
+    get '/ping'
+
+    assert_equal 200, last_response.status
+    assert_equal '', last_response.body
+  end
+
+  def test_health_check_does_not_override_app_endpoint
+    app.routes.draw { get '/ping', to: proc { [200, {}, ['Yo!']] } }
+
+    get '/ping'
+
+    assert_equal 200, last_response.status
+    assert_equal 'Yo!', last_response.body
+  end
+end

--- a/wet-health_endpoint.gemspec
+++ b/wet-health_endpoint.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rack-test", "~> 0.6.3"
-  spec.add_development_dependency "rails", "~> 4.1"
+  spec.add_development_dependency "rails", "~> 5.0"
 end


### PR DESCRIPTION
Adds Rails configuration option `health_endpoint` in order to be able to set a custom HTTP status and endpoint.